### PR TITLE
Prevent trains changing destination mid arrival and getting stuck.

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -2,7 +2,7 @@ script.on_event(
     {defines.events.on_train_changed_state, defines.events.on_train_schedule_changed},
     function(e)
         local train = e.train
-        if train.manual_mode == false and train.state ~= defines.train_state.wait_station then
+        if train.manual_mode == false and train.state ~= defines.train_state.wait_station and train.state ~= defines.train_state.arrive_station then
             UpdateNextTrainStation(train)
         end
     end


### PR DESCRIPTION
I run two-headed trains with two-way stations as pictured [here](https://i.imgur.com/7cNl5Sj.png).

A train will be routed to the station by a circuit condition, however if that condition changes while en-route the mod will change the destination upon arrival leaving the train stuck halfway into the station as shown [here](https://i.imgur.com/g3XQnq9.png).

We can skip the `UpdateNextTrainStation` check if the train is arriving at a station.
This will cause the train to fully pull into the station before repathing to the next station if it's fulfilled.